### PR TITLE
Update to v3.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.0.3" %}
+{% set version = "3.1.1" %}
 
 package:
   name: libjpeg-turbo
@@ -6,17 +6,16 @@ package:
 
 source:
   url: https://github.com/libjpeg-turbo/libjpeg-turbo/archive/{{ version }}.tar.gz
-  sha256: a649205a90e39a548863a3614a9576a3fb4465f8e8e66d54999f127957c25b21
+  sha256: 304165ae11e64ab752e9cfc07c37bfdc87abd0bfe4bc699e59f34036d9c84f72
 
 build:
   number: 0
-  # We don't have yasm for s390x; libjpeg-turbo is needed for torchvision, which we won't build on s390x anyway
-  skip: True # [s390x]
   run_exports:
     - {{ pin_subpackage('libjpeg-turbo', max_pin='x') }}
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - cmake
     # https://github.com/libjpeg-turbo/libjpeg-turbo/blob/7fa4b5b762c9a99b46b0b7838f5fd55071b92ea5/BUILDING.md?plain=1#L16
@@ -48,7 +47,7 @@ test:
     - djpeg -dct int -ppm -outfile testout.ppm testorig.jpg
 
 about:
-  home: http://www.libjpeg-turbo.org/
+  home: https://www.libjpeg-turbo.org
   description: |
     libjpeg-turbo is a JPEG image codec that uses SIMD instructions (MMX, SSE2, AVX2, Neon, AltiVec) to accelerate
     baseline JPEG compression and decompression on x86, x86-64, Arm, and PowerPC systems, as well as progressive JPEG


### PR DESCRIPTION
libjpeg-turbo 3.1.1

**Destination channel:** defaults

### Links

- [PKG-9072](https://anaconda.atlassian.net/browse/PKG-9072)
- [Upstream repository](https://github.com/libjpeg-turbo/libjpeg-turbo/tree/3.1.1)
- [Upstream changelog/diff](https://github.com/libjpeg-turbo/libjpeg-turbo/compare/3.0.3...3.1.1)
- Relevant dependency PRs:
  - QtWebEngine v6.9.1


[PKG-9072]: https://anaconda.atlassian.net/browse/PKG-9072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ