### PR TITLE
Update version to 3.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,13 @@
-{% set version = "3.1.1" %}
+{% set version = "3.1.2" %}
+{% set name = "libjpeg-turbo" %}
 
 package:
-  name: libjpeg-turbo
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/libjpeg-turbo/libjpeg-turbo/archive/{{ version }}.tar.gz
-  sha256: 304165ae11e64ab752e9cfc07c37bfdc87abd0bfe4bc699e59f34036d9c84f72
+  url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: 560f6338b547544c4f9721b18d8b87685d433ec78b3c644c70d77adad22c55e6
 
 build:
   number: 0


### PR DESCRIPTION
libjpeg-turbo 3.1.2

**Destination channel:** defaults

### Links

- [PKG-10829](https://anaconda.atlassian.net/browse/PKG-10829) 
- [Upstream repository](https://github.com/libjpeg-turbo/libjpeg-turbo/tree/3.1.2)

### Explanation of changes:

- new version number


[PKG-10829]: https://anaconda.atlassian.net/browse/PKG-10829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ